### PR TITLE
MNT-20206 Improper Resource Shutdown or Release CWE ID 404

### DIFF
--- a/surf/spring-surf/spring-surf/src/main/java/org/springframework/extensions/surf/DependencyHandler.java
+++ b/surf/spring-surf/spring-surf/src/main/java/org/springframework/extensions/surf/DependencyHandler.java
@@ -668,15 +668,18 @@ public class DependencyHandler implements ApplicationContextAware, CacheReporter
         {
             final Writer writer = new StringBuilderWriter();
             final char[] buffer = new char[1024];
-            try
+            // MNT-20206: MNT-20206 Improper Resource Shutdown or Release CWE ID 404
+            // LM-2019-02-12
+            try (final Reader reader = new BufferedReader(new InputStreamReader(in, this.charset)))
             {
-                final Reader reader = new BufferedReader(new InputStreamReader(in, this.charset));
+//                final Reader reader = new BufferedReader(new InputStreamReader(in, this.charset));
                 int n;
                 while ((n = reader.read(buffer)) != -1) 
                 {
                     writer.write(buffer, 0, n);
                 }
                 s = writer.toString();
+                             
             } 
             finally 
             {


### PR DESCRIPTION
The application fails to release (or incorrectly releases) a system resource before it is made available for re-use. This condition often occurs with resources such as database connections or file handles. Most unreleased resource issues result in general software reliability problems, but if an attacker can intentionally trigger a resource leak, it may be possible to launch a denial of service attack by depleting the resource pool.

- updated try block with try-with-resources pattern to ensure bufferedReader is closed