### PR TITLE
Updated Snapshot version details

### DIFF
--- a/surf/pom.xml
+++ b/surf/pom.xml
@@ -14,7 +14,7 @@
    <name>Surf Modules</name>
    <description>Surf Web-Framework project and configuration information for Surf modules</description>
    <packaging>pom</packaging>
-   <version>9.2</version>
+   <version>9.3-SNAPSHOT</version>
 
    <distributionManagement>
       <repository>
@@ -55,9 +55,9 @@
 
    <properties>
       <!-- Surf projects historically use 'spring.version' property -->
-      <spring.version>6.1.13</spring.version>
+      <spring.version>6.1.14</spring.version>
       <dependency.alfresco-core.version>8.425</dependency.alfresco-core.version>
-      <dependency.webscripts.version>9.4</dependency.webscripts.version>
+      <dependency.webscripts.version>9.5</dependency.webscripts.version>
       <dependency.freemarker.version>2.3.30-jakarta-1</dependency.freemarker.version>
       <dependency.rhino.version>1.7.13</dependency.rhino.version>
       <dependency.yui.version>2.9.0-alfresco-20141223</dependency.yui.version>

--- a/surf/spring-cmis/pom.xml
+++ b/surf/spring-cmis/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.alfresco.surf</groupId>
         <artifactId>surf-parent</artifactId>
-        <version>9.2</version>
+        <version>9.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/surf/spring-surf-archetype/pom.xml
+++ b/surf/spring-surf-archetype/pom.xml
@@ -4,7 +4,7 @@
   <parent>
 	 <groupId>org.alfresco.surf</groupId>
 	 <artifactId>surf-parent</artifactId>
-	 <version>9.2</version>
+	 <version>9.3-SNAPSHOT</version>
 	 <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>spring-surf-archetype</artifactId>

--- a/surf/spring-surf-tests/spring-surf-extensibility-app/pom.xml
+++ b/surf/spring-surf-tests/spring-surf-extensibility-app/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.alfresco.surf</groupId>
       <artifactId>surf-parent</artifactId>
-      <version>9.2</version>
+      <version>9.3-SNAPSHOT</version>
       <relativePath>../../pom.xml</relativePath>
    </parent>
    

--- a/surf/spring-surf/spring-surf-api/pom.xml
+++ b/surf/spring-surf/spring-surf-api/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.alfresco.surf</groupId>
       <artifactId>surf-parent</artifactId>
-      <version>9.2</version>
+      <version>9.3-SNAPSHOT</version>
       <relativePath>../../pom.xml</relativePath>
    </parent>
    

--- a/surf/spring-surf/spring-surf/pom.xml
+++ b/surf/spring-surf/spring-surf/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.alfresco.surf</groupId>
       <artifactId>surf-parent</artifactId>
-      <version>9.2</version>
+      <version>9.3-SNAPSHOT</version>
       <relativePath>../../pom.xml</relativePath>
    </parent>
 

--- a/surf/spring-webeditor-client/spring-webeditor-client-jsp/pom.xml
+++ b/surf/spring-webeditor-client/spring-webeditor-client-jsp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.alfresco.surf</groupId>
 		<artifactId>surf-parent</artifactId>
-		<version>9.2</version>
+		<version>9.3-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>  
 	 

--- a/surf/spring-webeditor/spring-webeditor/pom.xml
+++ b/surf/spring-webeditor/spring-webeditor/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.alfresco.surf</groupId>
 		<artifactId>surf-parent</artifactId>
-		<version>9.2</version>
+		<version>9.3-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	


### PR DESCRIPTION
This update migrates the project core from spring 6.1.13 to 6.1.14, surf-webscripts 9.4 to 9.5 aiming to leverage the new features, security patches and performance improvements. While ensuring capability and optimization of the Surf repository.