### PR TITLE
[PRODSEC-9804] Updated spring, surf-webscripts version details

### DIFF
--- a/surf/pom.xml
+++ b/surf/pom.xml
@@ -55,9 +55,9 @@
 
    <properties>
       <!-- Surf projects historically use 'spring.version' property -->
-      <spring.version>6.1.13</spring.version>
+      <spring.version>6.1.14</spring.version>
       <dependency.alfresco-core.version>8.425</dependency.alfresco-core.version>
-      <dependency.webscripts.version>9.4</dependency.webscripts.version>
+      <dependency.webscripts.version>9.5</dependency.webscripts.version>
       <dependency.freemarker.version>2.3.30-jakarta-1</dependency.freemarker.version>
       <dependency.rhino.version>1.7.13</dependency.rhino.version>
       <dependency.yui.version>2.9.0-alfresco-20141223</dependency.yui.version>


### PR DESCRIPTION
This update migrates the project core from spring 6.1.13 to 6.1.14, surf-webscripts 9.4 to 9.5 aiming to leverage the new features, security patches and performance improvements. While ensuring capability and optimization of the Surf repository.