### PR TITLE
returning null from getResponse to avoid wrapping issue for tomcat 11

### DIFF
--- a/surf/spring-surf/spring-surf/src/main/java/org/springframework/extensions/surf/util/FakeHttpServletResponse.java
+++ b/surf/spring-surf/spring-surf/src/main/java/org/springframework/extensions/surf/util/FakeHttpServletResponse.java
@@ -138,6 +138,17 @@ public class FakeHttpServletResponse extends HttpServletResponseWrapper
         this.characterEncoding = characterEncoding;
     }
 
+    /**
+     * (non-Javadoc)
+     * Intentionally returns {@code null} to avoid exposing the wrapped response.
+     * @see jakarta.servlet.ServletResponseWrapper#getResponse()
+     */
+    @Override
+    public HttpServletResponse getResponse() {
+        return null;
+    }
+
+
     /*
      * (non-Javadoc)
      * @see javax.servlet.ServletResponse#getCharacterEncoding()


### PR DESCRIPTION
[Tomcat-11 update](https://hyland.atlassian.net/browse/ACS-10817?atlOrigin=eyJpIjoiZDUzYjk4MjE4NTk3NDZiZTgzNmNjOGRlNTVkM2MyNWYiLCJwIjoiaiJ9)